### PR TITLE
Support onnx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 model/
+__pycache__/
+*.wav

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Cyhton が便利です。
 4. あとは[README.md](https://github.com/Hiroshiba/voicevox_core/tree/f4844efc65b1a4875442091955af84f671e16887#%E3%82%BD%E3%83%BC%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%89%E3%81%8B%E3%82%89%E5%AE%9F%E8%A1%8C)にあるように`python setup.py install`などを実行
 5. import して[このように](https://github.com/Hiroshiba/voicevox_core/blob/f4844efc65b1a4875442091955af84f671e16887/example/python/run.py#L21-L25)つなぎこむ
 
+## モデルをonnxに変換
+* `python run.py --yukarin_s_model_dir "model/yukarin_s" --yukarin_sa_model_dir "model/yukarin_sa" --yukarin_sosoa_model_dir "model/yukarin_sosoa" --hifigan_model_dir "model/hifigan"  --speaker_ids 5  --method=convert` でonnxへの変換が可能。modelフォルダ内のyukarin_s, yukarin_sa, yukarin_sosoaフォルダにonnxが保存される。
+  - `speaker_ids`オプションに指定する数値は自由。どの数値を指定しても生成されるonnxモデルは全ての`speaker_id`に対応しており、値を変えて実行しなおしたり、複数のidを指定したりする必要は無い。
+  - yukarin_sosoaフォルダにはhifi_ganと合わせた`decode.onnx`が保存される
+
+* onnxで実行したい場合は`--method=onnx`とする； `python run.py --yukarin_s_model_dir "model/yukarin_s" --yukarin_sa_model_dir "model/yukarin_sa" --yukarin_sosoa_model_dir "model/yukarin_sosoa" --hifigan_model_dir "model/hifigan"  --speaker_ids 5  --method=onnx`
+  - `speaker_ids`に複数の数値を指定すれば、通常実行と同様に各話者の音声が保存される。
+
 ## ファイル構造
 
 - `run.py` ･･･ エントリーポイント
@@ -67,6 +75,13 @@ Cyhton が便利です。
     - `make_decode_forwarder`に必要な`yukarin_sosoa`用の`forwarder`を作る
   - `make_decode_forwarder.py`
     - 音声波形生成用の`forwarder`を作る
+  - `onnx_yukarin_s_forwarder.py`
+    - onnxruntimeで動作する`yukarin_s`用の`forwarder`を作る
+  - `onnx_yukarin_sa_forwarder.py`
+    - onnxruntimeで動作する`yukarin_sa`用の`forwarder`を作る
+  - `onnx_decode_forwarder.py`
+    - onnxruntimeで動作する音声波形生成用の`forwarder`を作る
+    - `yukarin_sosoa`も内部に組み込まれている
   - `acoustic_feature_extractor.py`
     - 音素情報やリサンプリング手法などが入っている。ディープラーニングとは関係ない。
   - `full_context_label.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 pyyaml
 soundfile
 torch==1.9.0
+onnxruntime
 git+https://github.com/Hiroshiba/yukarin_s@416f25603ff353f0691ce19b3a98f69af774a487
 git+https://github.com/Hiroshiba/yukarin_sa@18bbbefaaf49d4f19b77b3a863c33b4bb8afc7cf
 git+https://github.com/Hiroshiba/yukarin_sosoa@056124fbb1bc0f37bcd9432da0f18e7a04b28a62

--- a/run.py
+++ b/run.py
@@ -26,6 +26,9 @@ def run(
         from vv_core_inference.onnx_decode_forwarder import make_decode_forwarder
         from vv_core_inference.onnx_yukarin_s_forwarder import make_yukarin_s_forwarder
         from vv_core_inference.onnx_yukarin_sa_forwarder import make_yukarin_sa_forwarder
+        import onnxruntime
+        if use_gpu:
+            assert onnxruntime.get_device() == "GPU", "Install onnxruntime-gpu if you want to use GPU."
 
     convert = (method == "convert")
 

--- a/run.py
+++ b/run.py
@@ -6,10 +6,6 @@ from typing import List
 import soundfile
 
 from vv_core_inference.forwarder import Forwarder
-from vv_core_inference.make_decode_forwarder import make_decode_forwarder
-from vv_core_inference.make_yukarin_s_forwarder import make_yukarin_s_forwarder
-from vv_core_inference.make_yukarin_sa_forwarder import make_yukarin_sa_forwarder
-
 
 def run(
     yukarin_s_model_dir: Path,
@@ -19,17 +15,28 @@ def run(
     use_gpu: bool,
     texts: List[str],
     speaker_ids: List[int],
+    method: str,
 ):
     device = "cuda" if use_gpu else "cpu"
+    if method == "torch" or method == "convert":
+        from vv_core_inference.make_decode_forwarder import make_decode_forwarder
+        from vv_core_inference.make_yukarin_s_forwarder import make_yukarin_s_forwarder
+        from vv_core_inference.make_yukarin_sa_forwarder import make_yukarin_sa_forwarder
+    if method == "onnx":
+        from vv_core_inference.onnx_decode_forwarder import make_decode_forwarder
+        from vv_core_inference.onnx_yukarin_s_forwarder import make_yukarin_s_forwarder
+        from vv_core_inference.onnx_yukarin_sa_forwarder import make_yukarin_sa_forwarder
+
+    convert = (method == "convert")
 
     # yukarin_s
     yukarin_s_forwarder = make_yukarin_s_forwarder(
-        yukarin_s_model_dir=yukarin_s_model_dir, device=device
+        yukarin_s_model_dir=yukarin_s_model_dir, device=device, convert=convert
     )
 
     # yukarin_sa
     yukarin_sa_forwarder = make_yukarin_sa_forwarder(
-        yukarin_sa_model_dir=yukarin_sa_model_dir, device=device
+        yukarin_sa_model_dir=yukarin_sa_model_dir, device=device, convert=convert
     )
 
     # decoder
@@ -37,6 +44,7 @@ def run(
         yukarin_sosoa_model_dir=yukarin_sosoa_model_dir,
         hifigan_model_dir=hifigan_model_dir,
         device=device,
+        convert=convert
     )
 
     # Forwarder。このForwarderクラスの中を書き換えずに
@@ -51,7 +59,8 @@ def run(
         wave = forwarder.forward(
             text=text, speaker_id=speaker_id, f0_speaker_id=speaker_id
         )
-        soundfile.write(f"{text}-{speaker_id}.wav", data=wave, samplerate=24000)
+        if method == "torch" or method == "onnx":
+            soundfile.write(f"{method}-{text}-{speaker_id}.wav", data=wave, samplerate=24000)
 
 
 if __name__ == "__main__":
@@ -69,4 +78,5 @@ if __name__ == "__main__":
     parser.add_argument("--use_gpu", action="store_true")
     parser.add_argument("--texts", nargs="+", default=["こんにちは、どうでしょう"])
     parser.add_argument("--speaker_ids", nargs="+", type=int, default=[5, 9])
+    parser.add_argument("--method", choices=["torch", "convert", "onnx"], default="torch")
     run(**vars(parser.parse_args()))

--- a/test.py
+++ b/test.py
@@ -1,0 +1,99 @@
+import argparse
+from itertools import product
+from pathlib import Path
+from typing import List
+
+import numpy as np
+
+from vv_core_inference.forwarder import Forwarder
+
+def run(
+    yukarin_s_model_dir: Path,
+    yukarin_sa_model_dir: Path,
+    yukarin_sosoa_model_dir: Path,
+    hifigan_model_dir: Path,
+    use_gpu: bool,
+    texts: List[str],
+    speaker_ids: List[int],
+    method: str,
+):
+    if method == "torch":
+        from vv_core_inference.make_decode_forwarder import make_decode_forwarder
+        from vv_core_inference.make_yukarin_s_forwarder import make_yukarin_s_forwarder
+        from vv_core_inference.make_yukarin_sa_forwarder import make_yukarin_sa_forwarder
+    if method == "onnx":
+        from vv_core_inference.onnx_decode_forwarder import make_decode_forwarder
+        from vv_core_inference.onnx_yukarin_s_forwarder import make_yukarin_s_forwarder
+        from vv_core_inference.onnx_yukarin_sa_forwarder import make_yukarin_sa_forwarder
+
+    device = "cuda" if use_gpu else "cpu"
+    result = {
+        "s": None,
+        "sa": None,
+        "decode": None,
+    }
+
+    # yukarin_s
+    yukarin_s_forwarder = make_yukarin_s_forwarder(
+        yukarin_s_model_dir=yukarin_s_model_dir, device=device
+    )
+    def _s(**kwargs):
+        x = yukarin_s_forwarder(**kwargs)
+        result["s"] = x
+        return x
+
+    # yukarin_sa
+    yukarin_sa_forwarder = make_yukarin_sa_forwarder(
+        yukarin_sa_model_dir=yukarin_sa_model_dir, device=device
+    )
+    def _sa(**kwargs):
+        x = yukarin_sa_forwarder(**kwargs)
+        result["sa"] = x
+        return x
+
+    # decoder
+    decode_forwarder = make_decode_forwarder(
+        yukarin_sosoa_model_dir=yukarin_sosoa_model_dir,
+        hifigan_model_dir=hifigan_model_dir,
+        device=device,
+    )
+    def _decode(**kwargs):
+        x = decode_forwarder(**kwargs)
+        result["decode"] = x
+        return x
+
+    # Forwarder。このForwarderクラスの中を書き換えずに
+    # yukarin_s_forwarder、yukarin_sa_forwarder、decode_forwarderを置き換えたい。
+    forwarder = Forwarder(
+        yukarin_s_forwarder=_s,
+        yukarin_sa_forwarder=_sa,
+        decode_forwarder=_decode,
+    )
+
+    for text, speaker_id in product(texts, speaker_ids):
+        _wave = forwarder.forward(
+            text=text, speaker_id=speaker_id, f0_speaker_id=speaker_id
+        )
+    return result
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--yukarin_s_model_dir", type=Path, default=Path("model/yukarin_s")
+    )
+    parser.add_argument(
+        "--yukarin_sa_model_dir", type=Path, default=Path("model/yukarin_sa")
+    )
+    parser.add_argument(
+        "--yukarin_sosoa_model_dir", type=Path, default=Path("model/yukarin_sosoa")
+    )
+    parser.add_argument("--hifigan_model_dir", type=Path, default=Path("model/hifigan"))
+    parser.add_argument("--use_gpu", action="store_true")
+    parser.add_argument("--texts", nargs="+", default=["こんにちは、どうでしょう"])
+    parser.add_argument("--speaker_ids", nargs="+", type=int, default=[5, 9])
+
+    torch_result = run(**vars(parser.parse_args()), method="torch")
+    onnx_result = run(**vars(parser.parse_args()), method="onnx")
+
+    for key in ["s", "sa", "decode"]:
+        print(key, np.allclose(torch_result[key], onnx_result[key]))

--- a/test.py
+++ b/test.py
@@ -26,6 +26,7 @@ def run(
         from vv_core_inference.onnx_yukarin_s_forwarder import make_yukarin_s_forwarder
         from vv_core_inference.onnx_yukarin_sa_forwarder import make_yukarin_sa_forwarder
 
+    np.random.seed(0)
     device = "cuda" if use_gpu else "cpu"
     result = {
         "s": None,
@@ -97,3 +98,6 @@ if __name__ == "__main__":
 
     for key in ["s", "sa", "decode"]:
         print(key, np.allclose(torch_result[key], onnx_result[key]))
+
+    print(np.abs(torch_result["decode"] - onnx_result["decode"]).max())
+    print(np.abs(torch_result["decode"] - onnx_result["decode"]).max() / np.abs(torch_result["decode"]).max())

--- a/vv_core_inference/forwarder.py
+++ b/vv_core_inference/forwarder.py
@@ -135,16 +135,14 @@ class Forwarder:
 
         f0_list = self.yukarin_sa_forwarder(
             length=vowel_phoneme_list.shape[0],
-            vowel_phoneme_list=vowel_phoneme_list[numpy.newaxis],
-            consonant_phoneme_list=consonant_phoneme_list[numpy.newaxis],
-            start_accent_list=start_accent_list[vowel_indexes][numpy.newaxis],
-            end_accent_list=end_accent_list[vowel_indexes][numpy.newaxis],
-            start_accent_phrase_list=start_accent_phrase_list[vowel_indexes][
-                numpy.newaxis
-            ],
-            end_accent_phrase_list=end_accent_phrase_list[vowel_indexes][numpy.newaxis],
+            vowel_phoneme_list=vowel_phoneme_list,
+            consonant_phoneme_list=consonant_phoneme_list,
+            start_accent_list=start_accent_list[vowel_indexes],
+            end_accent_list=end_accent_list[vowel_indexes],
+            start_accent_phrase_list=start_accent_phrase_list[vowel_indexes],
+            end_accent_phrase_list=end_accent_phrase_list[vowel_indexes],
             speaker_id=numpy.array(speaker_id, dtype=numpy.int64).reshape(-1),
-        )[0]
+        )
         f0_list += f0_correct
 
         for i, p in enumerate(vowel_phoneme_data_list):

--- a/vv_core_inference/make_decode_forwarder.py
+++ b/vv_core_inference/make_decode_forwarder.py
@@ -38,13 +38,13 @@ class WrapperDecodeForwarder(nn.Module):
         phoneme: numpy.ndarray,
         speaker_id: Optional[numpy.ndarray] = None,
     ):
-        f0_list = [to_tensor(f0, device=self.device)]
-        phoneme_list = [to_tensor(phoneme, device=self.device)]
+        f0 = to_tensor(f0, device=self.device)
+        phoneme = to_tensor(phoneme, device=self.device)
 
         # forward sosoa
         spec = self.yukarin_sosoa_forwarder(
-            f0_list=f0_list, phoneme_list=phoneme_list, speaker_id=speaker_id
-        )[0]
+            f0=f0, phoneme=phoneme, speaker_id=speaker_id
+        )
 
         # forward hifi gan
         x = spec.T

--- a/vv_core_inference/make_yukarin_s_forwarder.py
+++ b/vv_core_inference/make_yukarin_s_forwarder.py
@@ -7,7 +7,7 @@ from torch import Tensor, nn
 from yukarin_s.config import Config
 from yukarin_s.network.predictor import Predictor, create_predictor
 
-from vv_core_inference.utility import to_tensor
+from vv_core_inference.utility import to_tensor, OPSET
 
 
 class WrapperYukarinS(nn.Module):
@@ -23,7 +23,7 @@ class WrapperYukarinS(nn.Module):
         return output
 
 
-def make_yukarin_s_forwarder(yukarin_s_model_dir: Path, device):
+def make_yukarin_s_forwarder(yukarin_s_model_dir: Path, device, convert=False):
     with yukarin_s_model_dir.joinpath("config.yaml").open() as f:
         config = Config.from_dict(yaml.safe_load(f))
 
@@ -41,6 +41,19 @@ def make_yukarin_s_forwarder(yukarin_s_model_dir: Path, device):
         if speaker_id is not None:
             speaker_id = to_tensor(speaker_id, device=device)
             speaker_id = speaker_id.reshape((1,)).to(torch.int64)
+        if convert:
+            torch.onnx.export(
+                yukarin_s_forwarder,
+                (phoneme_list, speaker_id),
+                yukarin_s_model_dir.joinpath("yukarin_s.onnx"),
+                opset_version=OPSET,
+                do_constant_folding=True,  # execute constant folding for optimization
+                input_names=["phoneme_list", "speaker_id"],
+                output_names=["phoneme_length"],
+                dynamic_axes={
+                    "phoneme_list": {0: "sequence"},
+                    "phoneme_length" : {0: "sequence"}})
+            print("yukarin_s has been converted to ONNX") 
         return yukarin_s_forwarder(phoneme_list, speaker_id).cpu().numpy()
 
     return _dispatcher

--- a/vv_core_inference/make_yukarin_sa_forwarder.py
+++ b/vv_core_inference/make_yukarin_sa_forwarder.py
@@ -21,14 +21,13 @@ class WrapperUniGRU(nn.Module):
 
 
 class WrapperYukarinSa(nn.Module):
-    def __init__(self, predictor: Predictor, device):
+    def __init__(self, predictor: Predictor):
         super().__init__()
         self.phoneme_embedder = predictor.phoneme_embedder
         self.speaker_embedder = predictor.speaker_embedder
         self.encoder = predictor.encoder
         self.ar_encoder = WrapperUniGRU(predictor.ar_encoder.rnn)
         self.post = predictor.post
-        self.device = device
 
     @torch.no_grad()
     def forward(
@@ -42,18 +41,12 @@ class WrapperYukarinSa(nn.Module):
         end_accent_phrase_list: Tensor,
         speaker_id: Optional[Tensor],
     ):
-        vowel_phoneme_list = to_tensor(vowel_phoneme_list, device=self.device).unsqueeze(0)
-        consonant_phoneme_list = to_tensor(consonant_phoneme_list, device=self.device).unsqueeze(0)
-        start_accent_list = to_tensor(start_accent_list, device=self.device).unsqueeze(0)
-        end_accent_list = to_tensor(end_accent_list, device=self.device).unsqueeze(0)
-        start_accent_phrase_list = to_tensor(
-            start_accent_phrase_list, device=self.device
-        ).unsqueeze(0)
-        end_accent_phrase_list = to_tensor(end_accent_phrase_list, device=self.device).unsqueeze(0)
-
-        if speaker_id is not None:
-            speaker_id = to_tensor(speaker_id, device=self.device)
-            speaker_id = speaker_id.reshape((-1,)).to(torch.int64)
+        vowel_phoneme_list = vowel_phoneme_list.unsqueeze(0)
+        consonant_phoneme_list = consonant_phoneme_list.unsqueeze(0)
+        start_accent_list = start_accent_list.unsqueeze(0)
+        end_accent_list = end_accent_list.unsqueeze(0)
+        start_accent_phrase_list = start_accent_phrase_list.unsqueeze(0)
+        end_accent_phrase_list = end_accent_phrase_list.unsqueeze(0)
 
         batch_size = 1
         length = vowel_phoneme_list.shape[1]
@@ -110,7 +103,7 @@ class WrapperYukarinSa(nn.Module):
             h = self.post(h)  # (batch_size, 1, length)
             f0 = h[:, 0, :]  # (batch_size, length)
 
-        return f0[0].cpu().numpy()  # (batch_size, length)
+        return f0[0]  # (length,)
 
 
 def make_yukarin_sa_forwarder(yukarin_sa_model_dir: Path, device):
@@ -125,5 +118,41 @@ def make_yukarin_sa_forwarder(yukarin_sa_model_dir: Path, device):
     predictor.eval().to(device)
     predictor.apply(remove_weight_norm)
     print("yukarin_sa loaded!")
+    wrapper = WrapperYukarinSa(predictor)
 
-    return WrapperYukarinSa(predictor, device)
+    def _dispatcher(
+        length: int,
+        vowel_phoneme_list: Tensor,
+        consonant_phoneme_list: Tensor,
+        start_accent_list: Tensor,
+        end_accent_list: Tensor,
+        start_accent_phrase_list: Tensor,
+        end_accent_phrase_list: Tensor,
+        speaker_id: Optional[Tensor],
+    ):
+        vowel_phoneme_list = to_tensor(vowel_phoneme_list, device=device)
+        consonant_phoneme_list = to_tensor(consonant_phoneme_list, device=device)
+        start_accent_list = to_tensor(start_accent_list, device=device)
+        end_accent_list = to_tensor(end_accent_list, device=device)
+        start_accent_phrase_list = to_tensor(
+            start_accent_phrase_list, device=device
+        )
+        end_accent_phrase_list = to_tensor(end_accent_phrase_list, device=device)
+
+        if speaker_id is not None:
+            speaker_id = to_tensor(speaker_id, device=device)
+            speaker_id = speaker_id.reshape((-1,)).to(torch.int64)
+
+        args = (
+            length,
+            vowel_phoneme_list,
+            consonant_phoneme_list,
+            start_accent_list,
+            end_accent_list,
+            start_accent_phrase_list,
+            end_accent_phrase_list,
+            speaker_id
+        )
+        return wrapper(*args).cpu().numpy()
+    return _dispatcher
+

--- a/vv_core_inference/make_yukarin_sa_forwarder.py
+++ b/vv_core_inference/make_yukarin_sa_forwarder.py
@@ -42,20 +42,20 @@ class WrapperYukarinSa(nn.Module):
         end_accent_phrase_list: Tensor,
         speaker_id: Optional[Tensor],
     ):
-        vowel_phoneme_list = to_tensor(vowel_phoneme_list, device=self.device)
-        consonant_phoneme_list = to_tensor(consonant_phoneme_list, device=self.device)
-        start_accent_list = to_tensor(start_accent_list, device=self.device)
-        end_accent_list = to_tensor(end_accent_list, device=self.device)
+        vowel_phoneme_list = to_tensor(vowel_phoneme_list, device=self.device).unsqueeze(0)
+        consonant_phoneme_list = to_tensor(consonant_phoneme_list, device=self.device).unsqueeze(0)
+        start_accent_list = to_tensor(start_accent_list, device=self.device).unsqueeze(0)
+        end_accent_list = to_tensor(end_accent_list, device=self.device).unsqueeze(0)
         start_accent_phrase_list = to_tensor(
             start_accent_phrase_list, device=self.device
-        )
-        end_accent_phrase_list = to_tensor(end_accent_phrase_list, device=self.device)
+        ).unsqueeze(0)
+        end_accent_phrase_list = to_tensor(end_accent_phrase_list, device=self.device).unsqueeze(0)
 
         if speaker_id is not None:
             speaker_id = to_tensor(speaker_id, device=self.device)
             speaker_id = speaker_id.reshape((-1,)).to(torch.int64)
 
-        batch_size = vowel_phoneme_list.shape[0]
+        batch_size = 1
         length = vowel_phoneme_list.shape[1]
 
         ph = self.phoneme_embedder(vowel_phoneme_list + 1) + self.phoneme_embedder(
@@ -110,7 +110,7 @@ class WrapperYukarinSa(nn.Module):
             h = self.post(h)  # (batch_size, 1, length)
             f0 = h[:, 0, :]  # (batch_size, length)
 
-        return f0.cpu().numpy()  # (batch_size, length)
+        return f0[0].cpu().numpy()  # (batch_size, length)
 
 
 def make_yukarin_sa_forwarder(yukarin_sa_model_dir: Path, device):

--- a/vv_core_inference/make_yukarin_sa_forwarder.py
+++ b/vv_core_inference/make_yukarin_sa_forwarder.py
@@ -7,7 +7,7 @@ from torch import Tensor, nn
 from yukarin_sa.config import Config
 from yukarin_sa.network.predictor import Predictor, create_predictor
 
-from vv_core_inference.utility import remove_weight_norm, to_tensor
+from vv_core_inference.utility import remove_weight_norm, to_tensor, OPSET
 
 
 class WrapperUniGRU(nn.Module):
@@ -28,19 +28,26 @@ class WrapperYukarinSa(nn.Module):
         self.encoder = predictor.encoder
         self.ar_encoder = WrapperUniGRU(predictor.ar_encoder.rnn)
         self.post = predictor.post
+        _rnn = self.ar_encoder.rnn
+        num_directions = 2 if _rnn.bidirectional else 1
+        self.ar_encoder_hidden_shape = (
+            _rnn.num_layers * num_directions,
+            1, _rnn.hidden_size)
 
     @torch.no_grad()
     def forward(
         self,
-        length: int,
+        length: Tensor,
         vowel_phoneme_list: Tensor,
         consonant_phoneme_list: Tensor,
         start_accent_list: Tensor,
         end_accent_list: Tensor,
         start_accent_phrase_list: Tensor,
         end_accent_phrase_list: Tensor,
-        speaker_id: Optional[Tensor],
+        speaker_id: Tensor,
     ):
+        batch_size = 1
+
         vowel_phoneme_list = vowel_phoneme_list.unsqueeze(0)
         consonant_phoneme_list = consonant_phoneme_list.unsqueeze(0)
         start_accent_list = start_accent_list.unsqueeze(0)
@@ -48,13 +55,10 @@ class WrapperYukarinSa(nn.Module):
         start_accent_phrase_list = start_accent_phrase_list.unsqueeze(0)
         end_accent_phrase_list = end_accent_phrase_list.unsqueeze(0)
 
-        batch_size = 1
-        length = vowel_phoneme_list.shape[1]
-
         ph = self.phoneme_embedder(vowel_phoneme_list + 1) + self.phoneme_embedder(
             consonant_phoneme_list + 1
-        )  # (batch_size, length, ?)
-        ph = ph.transpose(1, 2)  # (batch_size, ?, length)
+        )  # (batch_size, length, _phenome_emb)
+        ph = ph.transpose(1, 2)  # (batch_size, _phenome_emb, length)
 
         ah = torch.stack(
             [
@@ -70,43 +74,38 @@ class WrapperYukarinSa(nn.Module):
 
         h = torch.cat((ph, ah), dim=1)  # (batch_size, ?, length)
 
-        if speaker_id is not None:
-            speaker_id = self.speaker_embedder(speaker_id)  # (batch_size, ?)
-            speaker_id = speaker_id.unsqueeze(2)  # (batch_size, ?, 1)
-            speaker = speaker_id.expand(
-                speaker_id.shape[0], speaker_id.shape[1], ph.shape[2]
-            )  # (batch_size, ?, length)
-            h = torch.cat((h, speaker), dim=1)  # (batch_size, ?, length)
+        speaker_id = self.speaker_embedder(speaker_id)  # (batch_size, _speaker_emb)
+        speaker_id = speaker_id.unsqueeze(2)  # (batch_size, _speaker_emb, 1)
+        speaker = speaker_id.expand(
+            speaker_id.shape[0], speaker_id.shape[1], ph.shape[2]
+        )  # (batch_size, _speaker_emb, length)
+        encoder_input = torch.cat((h, speaker), dim=1)  # (batch_size, encoder_emb = _phoneme_emb + 4 + speaker_emb, length)
+        encoder_input = encoder_input.view(1, -1, length)
 
-        h = self.encoder(h)  # (batch_size, ?, length)
+        h = self.encoder(encoder_input)  # (batch_size, encoder_emb, length)
 
-        if self.ar_encoder is not None:
-            f0 = torch.zeros(
-                batch_size, length, dtype=h.dtype, device=h.device
-            )  # (batch_size, length)
+        f0_one = torch.zeros(
+            batch_size, 1, 1, dtype=h.dtype, device=h.device
+        )  # (batch_size, 1, 1)
 
-            f0_one = torch.zeros(
-                batch_size, 1, 1, dtype=h.dtype, device=h.device
-            )  # (batch_size, 1, 1)
-            hidden: Optional[Tensor] = None
-            for i in range(length):
-                h_one = h[:, :, i : i + 1]  # (batch_size, ?, 1)
-                h_one = torch.cat((h_one, f0_one), dim=1)  # (batch_size, ?, 1)
-                h_one, hidden = self.ar_encoder(
-                    h_one, hidden=hidden
-                )  # (batch_size, ?, 1)
-                f0_one = self.post(h_one)  # (batch_size, 1, 1)
+        hidden = torch.zeros(
+            self.ar_encoder_hidden_shape,
+            device=h.device)
+        f0 = []
+        for i in range(int(length)):
+            h_one = h[:, :, i : i + 1]  # (batch_size, encoder_emb, 1)
+            ar_encoder_input = torch.cat((h_one, f0_one), dim=1)  # (batch_size, encoder_emb+1, 1)
+            h_one, hidden = self.ar_encoder(
+                ar_encoder_input, hidden=hidden
+            )  # (batch_size, ?, 1)
+            f0_one = self.post(h_one)  # (batch_size, 1, 1)
 
-                f0[:, i] = f0_one[:, 0, 0]  # (batch_size, length)
+            f0 += [f0_one[:, 0, 0]]
 
-        else:
-            h = self.post(h)  # (batch_size, 1, length)
-            f0 = h[:, 0, :]  # (batch_size, length)
-
-        return f0[0]  # (length,)
+        return torch.stack(f0, dim=1)[0]  # (length,)
 
 
-def make_yukarin_sa_forwarder(yukarin_sa_model_dir: Path, device):
+def make_yukarin_sa_forwarder(yukarin_sa_model_dir: Path, device, convert=False):
     with yukarin_sa_model_dir.joinpath("config.yaml").open() as f:
         config = Config.from_dict(yaml.safe_load(f))
 
@@ -130,6 +129,7 @@ def make_yukarin_sa_forwarder(yukarin_sa_model_dir: Path, device):
         end_accent_phrase_list: Tensor,
         speaker_id: Optional[Tensor],
     ):
+        length = to_tensor(length, device=device).to(torch.int64)
         vowel_phoneme_list = to_tensor(vowel_phoneme_list, device=device)
         consonant_phoneme_list = to_tensor(consonant_phoneme_list, device=device)
         start_accent_list = to_tensor(start_accent_list, device=device)
@@ -151,8 +151,37 @@ def make_yukarin_sa_forwarder(yukarin_sa_model_dir: Path, device):
             end_accent_list,
             start_accent_phrase_list,
             end_accent_phrase_list,
-            speaker_id
+            speaker_id,
         )
-        return wrapper(*args).cpu().numpy()
+        output = wrapper(*args)
+        if convert:
+            torch.onnx.export(
+                torch.jit.script(wrapper),
+                args,
+                yukarin_sa_model_dir.joinpath("yukarin_sa.onnx"),
+                opset_version=OPSET,
+                do_constant_folding=True,
+                input_names=[
+                    "length",
+                    "vowel_phoneme_list",
+                    "consonant_phoneme_list",
+                    "start_accent_list",
+                    "end_accent_list",
+                    "start_accent_phrase_list",
+                    "end_accent_phrase_list",
+                    "speaker_id",
+                ],
+                output_names=["f0_list"],
+                dynamic_axes={
+                    "vowel_phoneme_list": {0: "length"},
+                    "consonant_phoneme_list": {0: "length"},
+                    "start_accent_list": {0: "length"},
+                    "end_accent_list": {0: "length"},
+                    "start_accent_phrase_list": {0: "length"},
+                    "end_accent_phrase_list": {0: "length"},
+                    "f0_list": {0: "length"}},
+                example_outputs=output)
+            print("yukarin_sa has been converted to ONNX")
+        return output.cpu().numpy()
     return _dispatcher
 

--- a/vv_core_inference/make_yukarin_sosoa_forwarder.py
+++ b/vv_core_inference/make_yukarin_sosoa_forwarder.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import List, Optional
+import math
 
 import numpy
 import torch
@@ -12,6 +13,60 @@ from yukarin_sosoa.network.predictor import Predictor, create_predictor
 
 from vv_core_inference.utility import remove_weight_norm, to_tensor
 
+class RelPositionalEncoding(torch.nn.Module):
+    """Variant of espnet_pytorch_library/transformer/embedding.py#RelPositionalEncoding
+    copyright 2019 shigeki karita
+    apache 2.0  (http://www.apache.org/licenses/license-2.0)
+    """
+    def __init__(self, d_model, dropout_rate, max_len=5000):
+        """Construct an PositionalEncoding object."""
+        super().__init__()
+        assert d_model % 2 == 0
+        self.d_model = d_model
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout = torch.nn.Dropout(p=dropout_rate)
+
+    def forward(self, x: torch.Tensor):
+        """Add positional encoding.
+
+        Args:
+            x (torch.Tensor): Input tensor (batch, time, `*`).
+
+        Returns:
+            torch.Tensor: Encoded tensor (batch, time, `*`).
+
+        """
+        # Suppose `i` means to the position of query vecotr and `j` means the
+        # position of key vector. We use position relative positions when keys
+        # are to the left (i>j) and negative relative positions otherwise (i<j).
+        pe_positive = torch.zeros(x.size(1), self.d_model//2, 2)
+        pe_negative = torch.zeros(x.size(1), self.d_model//2, 2)
+        position = torch.arange(0, x.size(1), dtype=torch.float32).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, self.d_model, 2, dtype=torch.float32)
+            * -(math.log(10000.0) / self.d_model)
+        )
+        pe_positive[:, :, 0] = torch.sin(position * div_term)
+        pe_positive[:, :, 1] = torch.cos(position * div_term)
+        pe_negative[:, :, 0] = torch.sin(-1 * position * div_term)
+        pe_negative[:, :, 1] = torch.cos(-1 * position * div_term)
+
+        pe_positive = pe_positive.view(x.size(1), self.d_model)
+        pe_negative = pe_negative.view(x.size(1), self.d_model)
+
+        # Reserve the order of positive indices and concat both positive and
+        # negative indices. This is used to support the shifting trick
+        # as in https://arxiv.org/abs/1901.02860
+        pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
+        pe_negative = pe_negative[1:].unsqueeze(0)
+        pe = torch.cat([pe_positive, pe_negative], dim=1)
+
+        x = x * self.xscale
+        pos_emb = pe[
+            :,
+            pe.size(1) // 2 - x.size(1) + 1 : pe.size(1) // 2 + x.size(1),
+        ]
+        return self.dropout(x), self.dropout(pos_emb)
 
 def make_pad_mask(lengths: Tensor):
     bs = lengths.shape[0]
@@ -82,13 +137,14 @@ def make_yukarin_sosoa_wrapper(yukarin_sosoa_model_dir: Path, device) -> nn.Modu
         config = Config.from_dict(yaml.safe_load(f))
 
     predictor = create_predictor(config.network)
+    pe = predictor.encoder.embed[-1]
+    predictor.encoder.embed[-1] = RelPositionalEncoding(pe.d_model, pe.dropout.p) # Use my dynamic positional encoding version
     state_dict = torch.load(
         yukarin_sosoa_model_dir.joinpath("model.pth"), map_location=device
     )
     predictor.load_state_dict(state_dict)
     predictor.eval().to(device)
     predictor.apply(remove_weight_norm)
-    predictor.encoder.embed[0].pe = predictor.encoder.embed[0].pe.to(device)
     print("yukarin_sosoa loaded!")
     return WrapperYukarinSosoa(predictor)
 

--- a/vv_core_inference/onnx_decode_forwarder.py
+++ b/vv_core_inference/onnx_decode_forwarder.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from numpy import ndarray
+import onnxruntime
+
+def make_decode_forwarder(yukarin_sosoa_model_dir: Path, hifigan_model_dir: Path, device, convert=False):
+    session = onnxruntime.InferenceSession(str(yukarin_sosoa_model_dir.joinpath("decode.onnx")))
+
+    def _dispatcher(
+        length: int,
+        phoneme_size: int,
+        f0: ndarray,
+        phoneme: ndarray,
+        speaker_id: Optional[ndarray] = None,
+    ):
+        f0 = np.asarray(f0)
+        phoneme = np.asarray(phoneme)
+        if speaker_id is not None:
+            speaker_id = np.asarray(speaker_id)
+            speaker_id = speaker_id.reshape((1,)).astype(np.int64)
+        return session.run(["wave"], {
+            "f0": f0,
+            "phoneme": phoneme,
+            "speaker_id": speaker_id,
+        })[0]
+    return _dispatcher

--- a/vv_core_inference/onnx_yukarin_s_forwarder.py
+++ b/vv_core_inference/onnx_yukarin_s_forwarder.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from numpy import ndarray
+import onnxruntime
+
+def make_yukarin_s_forwarder(yukarin_s_model_dir: Path, device, convert=False):
+    session = onnxruntime.InferenceSession(str(yukarin_s_model_dir.joinpath("yukarin_s.onnx")))
+
+    def _dispatcher(length: int, phoneme_list: ndarray, speaker_id: Optional[ndarray]):
+        phoneme_list = np.asarray(phoneme_list)
+        if speaker_id is not None:
+            speaker_id = np.asarray(speaker_id)
+            speaker_id = speaker_id.reshape((1,)).astype(np.int64)
+        return session.run(["phoneme_length"], {
+            "phoneme_list": phoneme_list,
+            "speaker_id": speaker_id,
+        })[0]
+    return _dispatcher

--- a/vv_core_inference/onnx_yukarin_sa_forwarder.py
+++ b/vv_core_inference/onnx_yukarin_sa_forwarder.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from numpy import ndarray
+import onnxruntime
+
+def make_yukarin_sa_forwarder(yukarin_sa_model_dir: Path, device, convert=False):
+    session = onnxruntime.InferenceSession(str(yukarin_sa_model_dir.joinpath("yukarin_sa.onnx")))
+
+    def _dispatcher(
+        length: int,
+        vowel_phoneme_list: ndarray,
+        consonant_phoneme_list: ndarray,
+        start_accent_list: ndarray,
+        end_accent_list: ndarray,
+        start_accent_phrase_list: ndarray,
+        end_accent_phrase_list: ndarray,
+        speaker_id: Optional[ndarray],
+    ):
+        length = np.asarray(length).astype(np.int64)
+        vowel_phoneme_list = np.asarray(vowel_phoneme_list)
+        consonant_phoneme_list = np.asarray(consonant_phoneme_list)
+        start_accent_list = np.asarray(start_accent_list)
+        end_accent_list = np.asarray(end_accent_list)
+        start_accent_phrase_list = np.asarray(
+            start_accent_phrase_list
+        )
+        end_accent_phrase_list = np.asarray(end_accent_phrase_list)
+
+        if speaker_id is not None:
+            speaker_id = np.asarray(speaker_id)
+            speaker_id = speaker_id.reshape((-1,)).astype(np.int64)
+
+        output = session.run(["f0_list"], {
+            "length": length,
+            "vowel_phoneme_list": vowel_phoneme_list,
+            "consonant_phoneme_list": consonant_phoneme_list,
+            "start_accent_list": start_accent_list,
+            "end_accent_list": end_accent_list,
+            "start_accent_phrase_list": start_accent_phrase_list,
+            "end_accent_phrase_list": end_accent_phrase_list,
+            "speaker_id": speaker_id,
+        })[0]
+        return output
+    return _dispatcher

--- a/vv_core_inference/utility.py
+++ b/vv_core_inference/utility.py
@@ -4,7 +4,8 @@ from typing import Any, Union
 import numpy
 import torch
 from torch import Tensor
-
+from torch.onnx.symbolic_helper import _onnx_main_opset, _onnx_stable_opsets
+OPSET = _onnx_stable_opsets[-1]
 
 def extract_number(f):
     s = re.findall(r"\d+", str(f))


### PR DESCRIPTION
related: https://github.com/Hiroshiba/voicevox_engine/issues/69

## TODO
- [x] np.finfoとpositional encodingのmax_lenは固定してしまった。おそらく生成波形が50秒を超えるとクラッシュする。
  * なんとかする
- [x] Cython wrapperの変更

## Description
* `python run.py --yukarin_s_model_dir "model/yukarin_s" --yukarin_sa_model_dir "model/yukarin_sa" --yukarin_sosoa_model_dir "model/yukarin_sosoa" --hifigan_model_dir "model/hifigan"  --speaker_ids 5  --method=convert` でonnxへの変換が可能。modelフォルダのyukarin_s, yukarin_sa, yukarin_sosoaにonnxが保存される

* yukarin_sosoaにはhifi_ganと合わせた`decode.onnx`が保存される

* onnxで実行したい場合は`--method=onnx`とする； `python run.py --yukarin_s_model_dir "model/yukarin_s" --yukarin_sa_model_dir "model/yukarin_sa" --yukarin_sosoa_model_dir "model/yukarin_sosoa" --hifigan_model_dir "model/hifigan"  --speaker_ids 5  --method=onnx`
おそらくtorchをimportしていない

* テストの結果波形の相対誤差が1e-3くらいになったがもっと小さくできるかは不明。decodeで何故か誤差が出てきてしまう
実際の重みで聞いてみる必要がある

* テストコマンド: `python test.py --yukarin_s_model_dir "model/yukarin_s" --yukarin_sa_model_dir "model/yukarin_sa" --yukarin_sosoa_model_dir "model/yukarin_sosoa" --hifigan_model_dir "model/hifigan"  --speaker_ids 6   --texts "おはようございます、こんにちは、こんばんは"`