### PR TITLE
use indexing instead of squeeze to infer the shapes easily

### DIFF
--- a/vv_core_inference/make_decode_forwarder.py
+++ b/vv_core_inference/make_decode_forwarder.py
@@ -41,7 +41,7 @@ class WrapperDecodeForwarder(nn.Module):
 
         # forward hifi gan
         x = spec.transpose(1, 0)
-        wave = self.hifi_gan_forwarder(x.unsqueeze(0)).squeeze()
+        wave = self.hifi_gan_forwarder(x.unsqueeze(0))[0, 0]
         return wave
 
 


### PR DESCRIPTION
https://github.com/VOICEVOX/voicevox_core/issues/74#issuecomment-1036345230 の解決になるかもしれない

decode末尾のsqueezeを[0, 0]のindexingに変更し、DirectML providerのshape推論を成功させる