### PR TITLE
最適化レベルをORT_ENABLE_BASICに

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -394,7 +394,7 @@ def fuse(onnx1: Path, onnx2: Path):
 def optim(path: Path, output_path: Path):
     """ONNX Runtime sessionを作るときに走る最適化を利用する"""
     sess_options = onnxruntime.SessionOptions()
-    sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
+    sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_BASIC
     sess_options.optimized_model_filepath = str(output_path)
     session = onnxruntime.InferenceSession(str(path), sess_options)
 


### PR DESCRIPTION
最適化レベルをORT_ENABLE_BASICにします。
これで大量に出てくるログは除去しつつ、デバイス依存の最適化はしない感じになりました。
（バージョンが上がると変わるかもなので要注意）

経緯

- https://github.com/VOICEVOX/voicevox_core/issues/422#issuecomment-1416539656