### PR TITLE
sosf（ピッチ輪郭モデル）も扱えるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Cyhton が便利です。
 * `python convert.py --yukarin_s_model_dir "model/yukarin_s" --yukarin_sa_model_dir "model/yukarin_sa" --yukarin_sosoa_model_dir "model/yukarin_sosoa" --hifigan_model_dir "model/hifigan"` でonnxへの変換が可能。modelフォルダ内のyukarin_s, yukarin_sa, yukarin_sosoaフォルダにonnxが保存される。
   - `speaker_ids`オプションに指定する数値は自由。どの数値を指定しても生成されるonnxモデルは全ての`speaker_id`に対応しており、値を変えて実行しなおしたり、複数のidを指定したりする必要は無い。
   - yukarin_sosoaフォルダにはhifi_ganと合わせた`decode.onnx`が保存される
+  - yukarin_sosfはオプショナルで、追加する場合は`--yukarin_sosf_model_dir "model/yukarin_sosf"`などを指定する
 
 * onnxで実行したい場合は`run.py`を`--method=onnx`で実行する； `python run.py --yukarin_s_model_dir "model" --yukarin_sa_model_dir "model" --yukarin_sosoa_model_dir "model" --hifigan_model_dir "model"  --speaker_ids 5  --method=onnx`
   - `speaker_ids`に複数の数値を指定すれば、通常実行と同様に各話者の音声が保存される。
@@ -72,6 +73,8 @@ Cyhton が便利です。
     - 音素ごとの長さを求めるモデル`yukarin_s`用の`forwarder`を作る
   - `make_yukarin_sa_forwarder.py`
     - モーラごとの音高を求めるモデル`yukarin_sa`用の`forwarder`を作る
+  - `make_yukarin_sosf_forwarder.py`
+    - モーラごとの音高からフレームごとの音高を求めるモデル`yukarin_sosf`用の`forwarder`を作る
   - `make_yukarin_sosoa_forwarder.py`
     - `make_decode_forwarder`に必要な`yukarin_sosoa`用の`forwarder`を作る
   - `make_decode_forwarder.py`
@@ -80,6 +83,8 @@ Cyhton が便利です。
     - onnxruntimeで動作する`yukarin_s`用の`forwarder`を作る
   - `onnx_yukarin_sa_forwarder.py`
     - onnxruntimeで動作する`yukarin_sa`用の`forwarder`を作る
+  - `onnx_yukarin_sosf_forwarder.py`
+    - onnxruntimeで動作する`yukarin_sosf`用の`forwarder`を作る
   - `onnx_decode_forwarder.py`
     - onnxruntimeで動作する音声波形生成用の`forwarder`を作る
     - `yukarin_sosoa`も内部に組み込まれている
@@ -93,6 +98,7 @@ Cyhton が便利です。
 ## 自分で学習したモデルの onnx を作りたい場合
 
 VOICEVOX をビルドするには以下の 3 つの onnx が必要です。
+（predict_contourはオプショナルです。）
 
 - predict_duration.onnx
   - 入力
@@ -144,6 +150,28 @@ VOICEVOX をビルドするには以下の 3 つの onnx が必要です。
     - f0_list
       - shape: [sequence]
       - dtype: float
+- predict_contour.onnx
+  - 入力
+    - f0_discrete
+      - shape: [length, 1]
+      - dtype: float
+      - 値は離散値だった f0 を長さ分だけ repeat したもの
+    - phoneme
+      - shape: [length]
+      - dtype: int
+      - 値は音素 id
+    - speaker_id
+      - shape: [1]
+      - dtype: int
+  - 出力
+    - f0_contour
+      - shape: [length]
+      - dtype: float
+      - 値は連続値の f0
+    - voiced
+      - shape: [length]
+      - dtype: bool
+      - 値は True か False
 - decode.onnx
   - 入力
     - f0

--- a/convert.py
+++ b/convert.py
@@ -144,8 +144,7 @@ def convert_contour(model_dir: Path, device: str, offset: int, working_dir: Path
     logger.info("spectrogram model is loaded!")
     logger.info("speaker size: %d" % size)
     args = (
-        to_tensor(sample_input["length"], device=device).long(),
-        to_tensor(sample_input["f0"], device=device),
+        to_tensor(sample_input["f0_discrete"], device=device),
         to_tensor(sample_input["phoneme"], device=device),
         to_tensor(sample_input["speaker_id"], device=device).reshape((1,)).long()
     )
@@ -158,12 +157,11 @@ def convert_contour(model_dir: Path, device: str, offset: int, working_dir: Path
         opset_version=OPSET,
         do_constant_folding=True,
         input_names=[
-            "length",
-            "f0",
+            "f0_discrete",
             "phoneme",
             "speaker_id"
         ],
-        output_names=["f0", "voiced"],
+        output_names=["f0_contour", "voiced"],
         dynamic_axes={
             "f0": {0: "length"},
             "phoneme": {0: "length"},

--- a/convert.py
+++ b/convert.py
@@ -3,33 +3,35 @@ Pytorchモデルを読み込んでONNXモデルに変換する。
 モデルを複数指定した場合は、それらを並列に接続し入力によって実行パスが切り替わるモデルが作成される。
 例えば6話者のmodel1と10話者のmodel2が接続された場合は、入力speaker_idが0-5の時はmodel1が、6-15の時はmodel2が動作するONNXモデルが生成される。
 各モデルに含まれている話者数はconfigファイルから推定される。
-複数指定可能なモデルはduration, intonation, spectrogram推定。
+複数指定可能なモデルはduration, intonation, contour, spectrogram推定。
 vocoderは並列化することができず、全ての入力パターンに対してモデルが共有される。
 """
 import argparse
 import logging
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
-import torch
 import onnx
-import onnx.helper
 import onnx.compose
+import onnx.helper
 import onnxruntime
+import torch
 import yaml
 
-from vv_core_inference.utility import to_tensor, OPSET
+from vv_core_inference.forwarder import Forwarder
 from vv_core_inference.make_decode_forwarder import make_decode_forwarder
 from vv_core_inference.make_yukarin_s_forwarder import make_yukarin_s_forwarder
 from vv_core_inference.make_yukarin_sa_forwarder import make_yukarin_sa_forwarder
-from vv_core_inference.forwarder import Forwarder
+from vv_core_inference.make_yukarin_sosf_forwarder import make_yukarin_sosf_forwarder
+from vv_core_inference.utility import OPSET, to_tensor
 
 
 def convert_duration(model_dir: Path, device: str, offset: int, working_dir: Path, sample_input):
     """duration推定モデル(yukarin_s)のONNX変換"""
-    from vv_core_inference.make_yukarin_s_forwarder import WrapperYukarinS
     from yukarin_s.config import Config
     from yukarin_s.network.predictor import create_predictor
+
+    from vv_core_inference.make_yukarin_s_forwarder import WrapperYukarinS
 
     logger = logging.getLogger("duration")
     with model_dir.joinpath("config.yaml").open() as f:
@@ -67,9 +69,10 @@ def convert_duration(model_dir: Path, device: str, offset: int, working_dir: Pat
 
 def convert_intonation(model_dir: Path, device: str, offset: int, working_dir: Path, sample_input):
     """intonation推定モデル(yukarin_sa)のONNX変換"""
-    from vv_core_inference.make_yukarin_sa_forwarder import WrapperYukarinSa
     from yukarin_sa.config import Config
     from yukarin_sa.network.predictor import create_predictor
+
+    from vv_core_inference.make_yukarin_sa_forwarder import WrapperYukarinSa
     from vv_core_inference.utility import remove_weight_norm
 
     logger = logging.getLogger("intonation")
@@ -130,9 +133,50 @@ def convert_intonation(model_dir: Path, device: str, offset: int, working_dir: P
     )
     return outpath, size
 
+def convert_contour(model_dir: Path, device: str, offset: int, working_dir: Path, sample_input):
+    """contour推定モデル(yukarin_sosf)のONNX変換"""
+    from vv_core_inference.make_yukarin_sosf_forwarder import make_yukarin_sosf_wrapper
+
+    logger = logging.getLogger("contour")
+
+    wrapper = make_yukarin_sosf_wrapper(model_dir, device)
+    size = wrapper.speaker_embedder.num_embeddings
+    logger.info("spectrogram model is loaded!")
+    logger.info("speaker size: %d" % size)
+    args = (
+        to_tensor(sample_input["length"], device=device).long(),
+        to_tensor(sample_input["f0"], device=device),
+        to_tensor(sample_input["phoneme"], device=device),
+        to_tensor(sample_input["speaker_id"], device=device).reshape((1,)).long()
+    )
+
+    outpath = working_dir.joinpath(f"contour-{offset:03d}.onnx")
+    torch.onnx.export(
+        wrapper,
+        args,
+        outpath,
+        opset_version=OPSET,
+        do_constant_folding=True,
+        input_names=[
+            "length",
+            "f0",
+            "phoneme",
+            "speaker_id"
+        ],
+        output_names=["f0", "voiced"],
+        dynamic_axes={
+            "f0": {0: "length"},
+            "phoneme": {0: "length"},
+            "voiced": {0: "length"},
+        },
+    )
+    return outpath, size
+
 def convert_spectrogram(model_dir: Path, device: str, offset: int, working_dir: Path, sample_input):
     """spectrogram推定モデル(decodeの前半, yukarin_sosoa)のONNX変換"""
-    from vv_core_inference.make_yukarin_sosoa_forwarder import make_yukarin_sosoa_wrapper
+    from vv_core_inference.make_yukarin_sosoa_forwarder import (
+        make_yukarin_sosoa_wrapper,
+    )
 
     logger = logging.getLogger("spectrogram")
 
@@ -174,7 +218,10 @@ def convert_vocoder(model_dir: Path, device: str, working_dir: Path, sample_inpu
 
     wrapper = make_hifigan_wrapper(model_dir, device)
     logger.info("vocoder model is loaded!")
-    args = (to_tensor(sample_input, device=device),)
+    args = (
+        to_tensor(sample_input["spec"], device=device),
+        to_tensor(sample_input["f0"], device=device),
+    )
     outpath = working_dir.joinpath(f"vocoder.onnx")
     torch.onnx.export(
         wrapper,
@@ -182,9 +229,12 @@ def convert_vocoder(model_dir: Path, device: str, working_dir: Path, sample_inpu
         outpath,
         opset_version=OPSET,
         do_constant_folding=True,
-        input_names=["spec"],
+        input_names=["spec", "f0"],
         output_names=["wave"],
-        dynamic_axes={"spec": {0: "row", 1: "col"}}
+        dynamic_axes={
+            "spec": {0: "row", 1: "col"},
+            "f0": {0: "length"},
+        }
     )
     return outpath
 
@@ -192,6 +242,7 @@ def convert_vocoder(model_dir: Path, device: str, working_dir: Path, sample_inpu
 def get_sample_inputs(
     yukarin_s_model_dir: Path,
     yukarin_sa_model_dir: Path,
+    yukarin_sosf_model_dir: Optional[Path],
     yukarin_sosoa_model_dir: Path,
     hifigan_model_dir: Path,
     sample_text: str,
@@ -209,6 +260,15 @@ def get_sample_inputs(
         yukarin_sa_model_dir=yukarin_sa_model_dir, device=device
     )
 
+    # yukarin_sosf_forwarder
+    if yukarin_sosf_model_dir is not None:
+        yukarin_sosf_forwarder = make_yukarin_sosf_forwarder(
+            yukarin_sosf_model_dir=yukarin_sosf_model_dir,
+            device=device
+        )
+    else:
+        yukarin_sosf_forwarder = None
+
     # decoder
     decode_forwarder = make_decode_forwarder(
         yukarin_sosoa_model_dir=yukarin_sosoa_model_dir,
@@ -219,6 +279,7 @@ def get_sample_inputs(
     forwarder = Forwarder(
         yukarin_s_forwarder=yukarin_s_forwarder,
         yukarin_sa_forwarder=yukarin_sa_forwarder,
+        yukarin_sosf_forwarder=yukarin_sosf_forwarder,
         decode_forwarder=decode_forwarder,
     )
 
@@ -401,6 +462,7 @@ def optim(path: Path, output_path: Path):
 def run(
     yukarin_s_model_dir: List[Path],
     yukarin_sa_model_dir: List[Path],
+    yukarin_sosf_model_dir: Optional[List[Path]],
     yukarin_sosoa_model_dir: List[Path],
     hifigan_model_dir: Path,
     working_dir: Path,
@@ -412,7 +474,10 @@ def run(
     device = "cuda" if use_gpu else "cpu"
 
     model_size = len(yukarin_s_model_dir)
+    if yukarin_sosf_model_dir is None:
+        yukarin_sosf_model_dir = [None] * model_size
     assert model_size == len(yukarin_sa_model_dir)
+    assert model_size == len(yukarin_sosf_model_dir)
     assert model_size == len(yukarin_sosoa_model_dir)
 
     assert working_dir.exists() and working_dir.is_dir()
@@ -426,19 +491,21 @@ def run(
 
     duration_onnx_list = []
     intonation_onnx_list = []
+    contour_onnx_list = []
     spectrogram_onnx_list = []
 
     offsets = [0]
-    for idx, s_dir, sa_dir, sosoa_dir in zip(
-        range(model_size), yukarin_s_model_dir, yukarin_sa_model_dir, yukarin_sosoa_model_dir
+    for idx, s_dir, sa_dir, sosf_dir, sosoa_dir in zip(
+        range(model_size), yukarin_s_model_dir, yukarin_sa_model_dir, yukarin_sosf_model_dir, yukarin_sosoa_model_dir
     ):
         logger.info(f"[{idx+1}/{model_size}] Start converting models")
         logger.info(f"duration: {s_dir}")
         logger.info(f"intonation: {sa_dir}")
+        logger.info(f"contour: {sosf_dir}")
         logger.info(f"spectrogram: {sosoa_dir}")
 
         sample_inputs = get_sample_inputs(
-            s_dir, sa_dir, sosoa_dir, hifigan_model_dir, text, speaker_id, device
+            s_dir, sa_dir, sosf_dir, sosoa_dir, hifigan_model_dir, text, speaker_id, device
         )
 
         logger.info("duration model START")
@@ -450,14 +517,21 @@ def run(
         intonation_onnx, intonation_size = convert_intonation(sa_dir, device, offsets[-1], working_dir, sample_inputs["yukarin_sa_input"])
         intonation_onnx_list.append(intonation_onnx)
         logger.info("intonation model DONE")
+        assert duration_size == intonation_size
+
+        if sosf_dir is not None:
+            logger.info("contour model START")
+            contour_onnx, contour_size = convert_contour(sosf_dir, device, offsets[-1], working_dir, sample_inputs["yukarin_sosf_input"])
+            contour_onnx_list.append(contour_onnx)
+            logger.info("contour model DONE")
+            assert duration_size == contour_size
 
         logger.info("spec model START")
         spec_onnx, spec_size = convert_spectrogram(sosoa_dir, device, offsets[-1], working_dir, sample_inputs["yukarin_sosoa_input"])
         spectrogram_onnx_list.append(spec_onnx)
         logger.info("spec model DONE")
-
-        assert duration_size == intonation_size
         assert duration_size == spec_size
+
         offsets.append(offsets[-1] + duration_size)
     
     logger.info(f"collected offsets: {offsets}")
@@ -468,11 +542,13 @@ def run(
     logger.info("--- concatination ---")
     duration_merged_onnx = concat(duration_onnx_list, offsets)
     intonation_merged_onnx = concat(intonation_onnx_list, offsets)
+    contour_merged_onnx = concat(contour_onnx_list, offsets)
     spectrogram_merged_onnx = concat(spectrogram_onnx_list, offsets)
     decoder_onnx = fuse(spectrogram_merged_onnx, vocoder_onnx)
     logger.info("--- optimization ---")
     optim(duration_merged_onnx, working_dir / "duration.onnx")
     optim(intonation_merged_onnx, working_dir / "intonation.onnx")
+    optim(contour_merged_onnx, working_dir / "contour.onnx")
     optim(decoder_onnx, working_dir / "decode.onnx")
     logger.info("--- DONE! ---")
 
@@ -486,6 +562,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--yukarin_sa_model_dir", type=Path, nargs="*", default=[Path("model/yukarin_sa")]
+    )
+    parser.add_argument(
+        "--yukarin_sosf_model_dir", type=Path, nargs="*", default=None
     )
     parser.add_argument(
         "--yukarin_sosoa_model_dir", type=Path, nargs="*", default=[Path("model/yukarin_sosoa")]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ torch==1.9.0
 onnx==1.13.0
 onnxruntime==1.13.1
 git+https://github.com/Hiroshiba/yukarin_s@416f25603ff353f0691ce19b3a98f69af774a487
-git+https://github.com/Hiroshiba/yukarin_sa@18bbbefaaf49d4f19b77b3a863c33b4bb8afc7cf
-git+https://github.com/Hiroshiba/yukarin_sosoa@056124fbb1bc0f37bcd9432da0f18e7a04b28a62
-git+https://github.com/Hiroshiba/hifi-gan@17601a07573309ee305c58bf87a041f267b1c0c8#egg=hifi_gan
+git+https://github.com/Hiroshiba/yukarin_sa@7d6eede06782c49a18ede1a67a49d969973650af
+git+https://github.com/Hiroshiba/yukarin_sosf@2f8915b4e7499541d44f170fb93e46f616e6009d
+git+https://github.com/Hiroshiba/yukarin_sosoa@4e37ef9629109b5fc63f4bc0a1470ff9a9ccd932
+git+https://github.com/Hiroshiba/hifi-gan@265da0f0f71923336615d6657f195ffdc6df25e4#egg=hifi_gan
 git+https://github.com/VOICEVOX/pyopenjtalk@f4ade29ef9a4f43d8605103cb5bacc29e0b2ccae#egg=pyopenjtalk

--- a/run.py
+++ b/run.py
@@ -37,6 +37,9 @@ def run(
         from vv_core_inference.onnx_yukarin_sa_forwarder import (
             make_yukarin_sa_forwarder,
         )
+        from vv_core_inference.onnx_yukarin_sosf_forwarder import (
+            make_yukarin_sosf_forwarder,
+        )
 
         if use_gpu:
             assert (

--- a/run.py
+++ b/run.py
@@ -23,28 +23,18 @@ def run(
     if method == "torch":
         from vv_core_inference.make_decode_forwarder import make_decode_forwarder
         from vv_core_inference.make_yukarin_s_forwarder import make_yukarin_s_forwarder
-        from vv_core_inference.make_yukarin_sa_forwarder import (
-            make_yukarin_sa_forwarder,
-        )
-        from vv_core_inference.make_yukarin_sosf_forwarder import (
-            make_yukarin_sosf_forwarder,
-        )
+        from vv_core_inference.make_yukarin_sa_forwarder import make_yukarin_sa_forwarder
+        from vv_core_inference.make_yukarin_sosf_forwarder import make_yukarin_sosf_forwarder
     if method == "onnx":
         import onnxruntime
 
         from vv_core_inference.onnx_decode_forwarder import make_decode_forwarder
         from vv_core_inference.onnx_yukarin_s_forwarder import make_yukarin_s_forwarder
-        from vv_core_inference.onnx_yukarin_sa_forwarder import (
-            make_yukarin_sa_forwarder,
-        )
-        from vv_core_inference.onnx_yukarin_sosf_forwarder import (
-            make_yukarin_sosf_forwarder,
-        )
+        from vv_core_inference.onnx_yukarin_sa_forwarder import make_yukarin_sa_forwarder
+        from vv_core_inference.onnx_yukarin_sosf_forwarder import make_yukarin_sosf_forwarder
 
         if use_gpu:
-            assert (
-                onnxruntime.get_device() == "GPU"
-            ), "Install onnxruntime-gpu if you want to use GPU."
+            assert onnxruntime.get_device() == "GPU", "Install onnxruntime-gpu if you want to use GPU."
 
     # yukarin_s
     yukarin_s_forwarder = make_yukarin_s_forwarder(
@@ -86,9 +76,7 @@ def run(
             text=text, speaker_id=speaker_id, f0_speaker_id=speaker_id
         )
         if method == "torch" or method == "onnx":
-            soundfile.write(
-                f"{method}-{text}-{speaker_id}.wav", data=wave, samplerate=24000
-            )
+            soundfile.write(f"{method}-{text}-{speaker_id}.wav", data=wave, samplerate=24000)
 
 
 if __name__ == "__main__":

--- a/vv_core_inference/forwarder.py
+++ b/vv_core_inference/forwarder.py
@@ -43,12 +43,8 @@ class Forwarder:
         self.yukarin_soso_phoneme_class = OjtPhoneme
 
     def forward(
-        self,
-        text: str,
-        speaker_id: int,
-        f0_speaker_id: int,
-        f0_correct: float = 0,
-        return_intermediate_results: bool = False,
+        self, text: str, speaker_id: int, f0_speaker_id: int, f0_correct: float = 0,
+        return_intermediate_results: bool = False
     ):
         rate = 200
         intermediate_results = {}
@@ -112,7 +108,7 @@ class Forwarder:
         yukarin_s_input = {
             "length": len(phoneme_list_s),
             "phoneme_list": numpy.ascontiguousarray(phoneme_list_s),
-            "speaker_id": numpy.array(f0_speaker_id, dtype=numpy.int64).reshape(-1),
+            "speaker_id": numpy.array(f0_speaker_id, dtype=numpy.int64).reshape(-1)
         }
         intermediate_results["yukarin_s_input"] = yukarin_s_input
         phoneme_length = self.yukarin_s_forwarder(**yukarin_s_input)
@@ -217,7 +213,7 @@ class Forwarder:
         intermediate_results["yukarin_sosoa_input"] = {
             "f0": decode_input["f0"],
             "phoneme": decode_input["phoneme"],
-            "speaker_id": decode_input["speaker_id"],
+            "speaker_id": decode_input["speaker_id"]
         }
         spec, wave = self.decode_forwarder(**decode_input)
         intermediate_results["hifigan_input"] = {"spec": spec, "f0": decode_input["f0"]}

--- a/vv_core_inference/forwarder.py
+++ b/vv_core_inference/forwarder.py
@@ -43,8 +43,12 @@ class Forwarder:
         self.yukarin_soso_phoneme_class = OjtPhoneme
 
     def forward(
-        self, text: str, speaker_id: int, f0_speaker_id: int, f0_correct: float = 0,
-        return_intermediate_results: bool = False
+        self,
+        text: str,
+        speaker_id: int,
+        f0_speaker_id: int,
+        f0_correct: float = 0,
+        return_intermediate_results: bool = False,
     ):
         rate = 200
         intermediate_results = {}
@@ -108,7 +112,7 @@ class Forwarder:
         yukarin_s_input = {
             "length": len(phoneme_list_s),
             "phoneme_list": numpy.ascontiguousarray(phoneme_list_s),
-            "speaker_id": numpy.array(f0_speaker_id, dtype=numpy.int64).reshape(-1)
+            "speaker_id": numpy.array(f0_speaker_id, dtype=numpy.int64).reshape(-1),
         }
         intermediate_results["yukarin_s_input"] = yukarin_s_input
         phoneme_length = self.yukarin_s_forwarder(**yukarin_s_input)
@@ -170,8 +174,7 @@ class Forwarder:
         # forward yukarin sosf
         if self.yukarin_sosf_forwarder is not None:
             yukarin_sosf_input = {
-                "length": phoneme.shape[0],
-                "f0": f0[:, numpy.newaxis],
+                "f0_discrete": f0[:, numpy.newaxis],
                 "phoneme": phoneme,
                 "speaker_id": numpy.array(speaker_id, dtype=numpy.int64).reshape(-1),
             }
@@ -213,7 +216,7 @@ class Forwarder:
         intermediate_results["yukarin_sosoa_input"] = {
             "f0": decode_input["f0"],
             "phoneme": decode_input["phoneme"],
-            "speaker_id": decode_input["speaker_id"]
+            "speaker_id": decode_input["speaker_id"],
         }
         spec, wave = self.decode_forwarder(**decode_input)
         intermediate_results["hifigan_input"] = {"spec": spec, "f0": decode_input["f0"]}

--- a/vv_core_inference/forwarder.py
+++ b/vv_core_inference/forwarder.py
@@ -179,6 +179,7 @@ class Forwarder:
                 "phoneme": phoneme,
                 "speaker_id": numpy.array(speaker_id, dtype=numpy.int64).reshape(-1),
             }
+            intermediate_results["yukarin_sosf_input"] = yukarin_sosf_input
             f0, voiced = self.yukarin_sosf_forwarder(**yukarin_sosf_input)
             f0[~voiced] = 0
 
@@ -219,7 +220,7 @@ class Forwarder:
             "speaker_id": decode_input["speaker_id"],
         }
         spec, wave = self.decode_forwarder(**decode_input)
-        intermediate_results["hifigan_input"] = spec
+        intermediate_results["hifigan_input"] = {"spec": spec, "f0": decode_input["f0"]}
         if return_intermediate_results:
             return wave, intermediate_results
         else:

--- a/vv_core_inference/make_decode_forwarder.py
+++ b/vv_core_inference/make_decode_forwarder.py
@@ -8,7 +8,7 @@ from hifi_gan.models import Generator as HifiGanPredictor
 from torch import nn
 
 from vv_core_inference.make_yukarin_sosoa_forwarder import make_yukarin_sosoa_wrapper
-from vv_core_inference.utility import OPSET, to_tensor
+from vv_core_inference.utility import to_tensor, OPSET
 
 
 class AttrDict(dict):

--- a/vv_core_inference/make_yukarin_sosf_forwarder.py
+++ b/vv_core_inference/make_yukarin_sosf_forwarder.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+from typing import List, Optional
+
+import numpy
+import torch
+import yaml
+from torch import Tensor, nn
+from yukarin_sosf.config import Config
+from yukarin_sosf.network.predictor import Predictor, create_predictor
+
+from vv_core_inference.make_yukarin_sosoa_forwarder import (
+    RelPositionalEncoding,
+    WrapperPostnet,
+)
+from vv_core_inference.utility import remove_weight_norm, to_tensor
+
+
+class WrapperYukarinSosf(nn.Module):
+    def __init__(self, predictor: Predictor):
+        super().__init__()
+
+        self.speaker_embedder = predictor.speaker_embedder
+        self.phoneme_embedder = predictor.phoneme_embedder
+        self.pre = predictor.pre
+        self.encoder = predictor.encoder
+        self.post = predictor.post
+        self.postnet = WrapperPostnet(predictor.postnet)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        f0: Tensor,
+        phoneme: Tensor,
+        speaker_id: Tensor,
+    ):
+        f0 = f0.unsqueeze(0)
+        phoneme = phoneme.unsqueeze(0)
+
+        phoneme = self.phoneme_embedder(phoneme)  # (B, L, ?)
+
+        speaker_id = self.speaker_embedder(speaker_id)
+        speaker_id = speaker_id.unsqueeze(dim=1)  # (B, 1, ?)
+        speaker_feature = speaker_id.expand(
+            speaker_id.shape[0], f0.shape[1], speaker_id.shape[2]
+        )  # (B, L, ?)
+
+        h = torch.cat((f0, phoneme, speaker_feature), dim=2)  # (B, L, ?)
+        h = self.pre(h)
+
+        mask = torch.ones_like(f0).squeeze()
+        h, _ = self.encoder(h, mask)
+
+        output1 = self.post(h)
+        output2 = output1 + self.postnet(output1.transpose(1, 2)).transpose(1, 2)
+        return output2[0]
+
+
+def make_yukarin_sosf_wrapper(yukarin_sosf_model_dir: Path, device) -> nn.Module:
+    with yukarin_sosf_model_dir.joinpath("config.yaml").open() as f:
+        config = Config.from_dict(yaml.safe_load(f))
+
+    predictor = create_predictor(config.network)
+    pe = predictor.encoder.embed[-1]
+    predictor.encoder.embed[-1] = RelPositionalEncoding(
+        pe.d_model, pe.dropout.p
+    )  # Use my dynamic positional encoding version
+    state_dict = torch.load(
+        yukarin_sosf_model_dir.joinpath("model.pth"), map_location=device
+    )
+    predictor.load_state_dict(state_dict)
+    predictor.eval().to(device)
+    predictor.apply(remove_weight_norm)
+    print("yukarin_sosf loaded!")
+    return WrapperYukarinSosf(predictor)
+
+
+def make_yukarin_sosf_forwarder(yukarin_sosf_model_dir: Path, device):
+    yukarin_sosf_forwarder = make_yukarin_sosf_wrapper(yukarin_sosf_model_dir, device)
+
+    def _dispatcher(
+        length: int,
+        f0: numpy.ndarray,
+        phoneme: numpy.ndarray,
+        speaker_id: Optional[numpy.ndarray] = None,
+    ):
+        f0 = to_tensor(f0, device=device)
+        phoneme = to_tensor(phoneme, device=device)
+        if speaker_id is not None:
+            speaker_id = to_tensor(speaker_id, device=device)
+        output = yukarin_sosf_forwarder(f0, phoneme, speaker_id)
+        f0, voiced = output[:, 0], output[:, 1]
+        voiced = voiced > 0
+        return f0.cpu().numpy(), voiced.cpu().numpy()
+
+    return _dispatcher

--- a/vv_core_inference/onnx_yukarin_sosf_forwarder.py
+++ b/vv_core_inference/onnx_yukarin_sosf_forwarder.py
@@ -15,26 +15,23 @@ def make_yukarin_sosf_forwarder(yukarin_sosf_model_dir: Path, device, convert=Fa
     )
 
     def _dispatcher(
-        length: int,
-        f0: np.ndarray,
+        f0_discrete: np.ndarray,
         phoneme: np.ndarray,
         speaker_id: Optional[np.ndarray] = None,
     ):
-        length = np.asarray(length).astype(np.int64)
-        f0 = np.asarray(f0)
+        f0_discrete = np.asarray(f0_discrete)
         phoneme = np.asarray(phoneme)
         if speaker_id is not None:
             speaker_id = np.asarray(speaker_id).astype(np.int64)
 
-        f0, voiced = session.run(
-            ["f0", "voiced"],
+        f0_contour, voiced = session.run(
+            ["f0_contour", "voiced"],
             {
-                "length": length,
-                "f0": f0,
+                "f0_discrete": f0_discrete,
                 "phoneme": phoneme,
                 "speaker_id": speaker_id,
             },
         )
-        return f0, voiced
+        return f0_contour, voiced
 
     return _dispatcher

--- a/vv_core_inference/onnx_yukarin_sosf_forwarder.py
+++ b/vv_core_inference/onnx_yukarin_sosf_forwarder.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import onnxruntime
+from numpy import ndarray
+
+
+def make_yukarin_sosf_forwarder(yukarin_sosf_model_dir: Path, device, convert=False):
+    providers = ["CPUExecutionProvider"]
+    if device == "cuda":
+        providers.insert(0, "CUDAExecutionProvider")
+    session = onnxruntime.InferenceSession(
+        str(yukarin_sosf_model_dir.joinpath("contour.onnx")), providers=providers
+    )
+
+    def _dispatcher(
+        length: int,
+        f0: np.ndarray,
+        phoneme: np.ndarray,
+        speaker_id: Optional[np.ndarray] = None,
+    ):
+        length = np.asarray(length).astype(np.int64)
+        f0 = np.asarray(f0)
+        phoneme = np.asarray(phoneme)
+        if speaker_id is not None:
+            speaker_id = np.asarray(speaker_id).astype(np.int64)
+
+        f0, voiced = session.run(
+            ["f0", "voiced"],
+            {
+                "length": length,
+                "f0": f0,
+                "phoneme": phoneme,
+                "speaker_id": speaker_id,
+            },
+        )
+        return f0, voiced
+
+    return _dispatcher


### PR DESCRIPTION
saで出したイントネーション（モーラ単位のf0）を、sosfでピッチ輪郭にできる（フレーム単位のF0）ようにしてみました。
ちなみにhifiganもf0入力可能なようになっています。

今の段階でなんとかsosfのonnx化はできた（？）のですが、そのonnxモデルを使ったrun.pyが動かないという状況です。
こうエラーが出ます。。
```bash
  File "C:\.venv\lib\site-packages\onnxruntime\capi\onnxruntime_inference_collection.py", line 200, in run
    return self._sess.run(output_names, input_feed, run_options)
onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Invalid Feed Input Name:f0
```

↓onnxに変換してonnxモデルで推論しようとするコマンドです。
```bash
python convert.py \
    --yukarin_s_model_dir "model/yukarin_s" \
    --yukarin_sa_model_dir "model/yukarin_sa" \
    --yukarin_sosf_model_dir "model/yukarin_sosf" \
    --yukarin_sosoa_model_dir "model/yukarin_sosoa" \
    --hifigan_model_dir "model/hifigan" \
    --speaker_id 0

python run.py \
    --yukarin_s_model_dir "model" \
    --yukarin_sa_model_dir "model" \
    --yukarin_sosf_model_dir "model" \
    --yukarin_sosoa_model_dir "model" \
    --hifigan_model_dir "model" \
    --speaker_ids 0 \
    --method onnx
```

↓ちなみにonnxを使わないpytorchでのrun.pyは動きます。
```bash
python run.py \
    --speaker_ids 0 1 2 3
```

@Yosshi999 さん、またお力お借りすることは可能でしょうか 🙇‍♂️ 

---

pthファイルなどは新しく[こちら](https://github.com/Hiroshiba/vv_core_inference/releases/tag/0.0.1)にあげなおしました。
差はsosfモデルがあること、hifiganにwith_hnフラグがあることです。

ちなみにhifiganのwith_hnフラグはfalseのモデルになっています。
厳密にはアップロードしているこのhifiganは「F0が入力できるけど無視される」モデルです。
（with_hnのtrue/falseで２つモデルを用意すると逆にややこしくなりそうだったので。。）