### PR TITLE
F0入力が必要なhifiganモデルを追加

### DIFF
--- a/check_contour.bash
+++ b/check_contour.bash
@@ -10,7 +10,7 @@ python run.py \
     --yukarin_sa_model_dir "model/yukarin_sa" \
     --yukarin_sosf_model_dir "model/yukarin_sosf" \
     --yukarin_sosoa_model_dir "model/yukarin_sosoa" \
-    --hifigan_model_dir "model/hifigan" \
+    --hifigan_model_dir "model/hnhifigan" \
     --speaker_ids 5 9
 
 python convert.py \
@@ -18,7 +18,7 @@ python convert.py \
     --yukarin_sa_model_dir "model/yukarin_sa" \
     --yukarin_sosf_model_dir "model/yukarin_sosf" \
     --yukarin_sosoa_model_dir "model/yukarin_sosoa" \
-    --hifigan_model_dir "model/hifigan" \
+    --hifigan_model_dir "model/hnhifigan" \
     --working_dir "$working_dir"
 
 python run.py \

--- a/check_contour_fuse.bash
+++ b/check_contour_fuse.bash
@@ -10,7 +10,7 @@ python convert.py \
     --yukarin_sa_model_dir "model/yukarin_sa" "model/yukarin_sa" \
     --yukarin_sosf_model_dir "model/yukarin_sosf" "model/yukarin_sosf" \
     --yukarin_sosoa_model_dir "model/yukarin_sosoa" "model/yukarin_sosoa" \
-    --hifigan_model_dir "model/hifigan" \
+    --hifigan_model_dir "model/hnhifigan" \
     --working_dir "$working_dir"
 
 python run.py \


### PR DESCRIPTION
sosfを使う場合はF0入力が必要なhifiganを使うのですが、サンプルとして含んでいたhifiganはF0を無視しています。
その影響でF0 input nodeが消えてしまっており、convert.pyでエラーになるはずのところが素通りしていました。
なのでF0入力をちゃんと使うhifiganモデルも追加しました。

check_contour.bashとかがエラーで落ちるはず。