### PR TITLE
DirectMLで動かなくなってたのを修正

### DIFF
--- a/vv_core_inference/make_yukarin_sosoa_forwarder.py
+++ b/vv_core_inference/make_yukarin_sosoa_forwarder.py
@@ -124,7 +124,7 @@ class WrapperYukarinSosoa(nn.Module):
 
         h = self.pre(h)
 
-        mask = torch.ones_like(f0).squeeze()
+        mask = torch.ones_like(f0)[:, :, 0]
         h, _ = self.encoder(h, None, mask)
 
         output1 = self.post(h)


### PR DESCRIPTION
こんな感じのエラーが出ていました

```
2024-12-22 04:46:24.5940435 [E:onnxruntime:, sequential_executor.cc:369 onnxruntime::SequentialExecutor::Execute] Non-zero status code returned while running Squeeze node. Name:'m0./Squeeze' Status Message: D:\a\_work\1\s\onnxruntime\core\providers\dml\DmlExecutionProvider\src\MLOperatorAuthorImpl.cpp(2058)\onnxruntime_pybind11_state.pyd!00007FFC8D14FBE8: (caller: 00007FFC8D14F8A5) Exception(2) tid(6d18)
```

前からあったSqueeze箇所がうまく動かなくなったっぽかったです。
条件がよくわからないけど、↓のときと同じような感じかも。

- https://github.com/Hiroshiba/vv_core_inference/pull/3

onnxruntimeのバージョンを上げれば勝手に治りそうな気がしないでもないですが、まあ。
