### PR TITLE
pyopenjtalkをCMakeの問題を解決した0.4.1相当にアップデート

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ yukarin-s = { git = "https://github.com/Hiroshiba/yukarin_s", rev = "50556896d74
 yukarin-sa = { git = "https://github.com/Hiroshiba/yukarin_sa", rev = "2ad1065f94d61e53006e7311086294a8b1407b6f" }
 yukarin-sosoa = { git = "https://github.com/Hiroshiba/yukarin_sosoa", rev = "22aa731d56bb5f1c9fe4bfab12b661035cb4a0e2" }
 hifi-gan = { git = "https://github.com/Hiroshiba/hifi-gan", rev = "265da0f0f71923336615d6657f195ffdc6df25e4" }
-pyopenjtalk = { git = "https://github.com/VOICEVOX/pyopenjtalk", rev = "b35fc89fe42948a28e33aed886ea145a51113f88" }
+pyopenjtalk = { git = "https://github.com/VOICEVOX/pyopenjtalk", rev = "74703b034dd90a1f199f49bb70bf3b66b1728a86" }
 old-yukarin-sosoa = { git = "https://github.com/Hiroshiba/old_yukarin_sosoa", rev = "38dcd81805549658d2a8a6e871cbc75513154c7a" }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
@@ -913,6 +912,7 @@ name = "nvidia-nccl-cu12"
 version = "2.20.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/bb/d09dda47c881f9ff504afd6f9ca4f502ded6d8fc2f572cacc5e39da91c28/nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1fc150d5c3250b170b29410ba682384b14581db722b2531b0d8d33c595f33d01", size = 176238458 },
     { url = "https://files.pythonhosted.org/packages/4b/2a/0a131f572aa09f741c30ccd45a8e56316e8be8dfc7bc19bf0ab7cfef7b19/nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:057f6bf9685f75215d0c53bf3ac4a10b3e6578351de307abad9e18a99182af56", size = 176249402 },
 ]
 
@@ -922,6 +922,7 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836 },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204 },
 ]
 
 [[package]]
@@ -1176,11 +1177,10 @@ wheels = [
 
 [[package]]
 name = "pyopenjtalk"
-version = "0.3.2+b35fc89"
-source = { git = "https://github.com/VOICEVOX/pyopenjtalk?rev=b35fc89fe42948a28e33aed886ea145a51113f88#b35fc89fe42948a28e33aed886ea145a51113f88" }
+version = "0.1.dev251+g74703b034"
+source = { git = "https://github.com/VOICEVOX/pyopenjtalk?rev=74703b034dd90a1f199f49bb70bf3b66b1728a86#74703b034dd90a1f199f49bb70bf3b66b1728a86" }
 dependencies = [
     { name = "numpy" },
-    { name = "six" },
     { name = "tqdm" },
 ]
 
@@ -1706,7 +1706,7 @@ requires-dist = [
     { name = "old-yukarin-sosoa", git = "https://github.com/Hiroshiba/old_yukarin_sosoa?rev=38dcd81805549658d2a8a6e871cbc75513154c7a" },
     { name = "onnx", specifier = "==1.14.0" },
     { name = "onnxruntime", specifier = "==1.15.1" },
-    { name = "pyopenjtalk", git = "https://github.com/VOICEVOX/pyopenjtalk?rev=b35fc89fe42948a28e33aed886ea145a51113f88" },
+    { name = "pyopenjtalk", git = "https://github.com/VOICEVOX/pyopenjtalk?rev=74703b034dd90a1f199f49bb70bf3b66b1728a86" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "ruff", specifier = ">=0.11.2" },
     { name = "soundfile", specifier = "==0.12.1" },


### PR DESCRIPTION
今の環境で実験できなくなってしまったので、pyopenjtalkのversionを上げました